### PR TITLE
Add team roster retrieval and visualization

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -42,6 +42,27 @@ def get_team_stats(team, year):
     return response.json()
 
 
+def get_team_roster(team, year):
+    """Fetches the roster for a given team and year."""
+    api_key = _get_api_key()
+    if not api_key:
+        raise Exception("API key not provided. Cannot fetch data.")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "accept": "application/json",
+    }
+    url = f"https://api.collegefootballdata.com/roster?year={year}&team={team}"
+    response = requests.get(url, headers=headers)
+
+    if response.status_code != 200:
+        raise Exception(
+            f"Failed to fetch roster for {team}: {response.status_code} — {response.text}"
+        )
+
+    return response.json()
+
+
 
 
 

--- a/matchup.py
+++ b/matchup.py
@@ -1,10 +1,12 @@
-from data_fetcher import get_team_stats
+from data_fetcher import get_team_stats, get_team_roster
 from utils import predict_score, calculate_win_probability
-from visuals import plot_team_comparison
+from visuals import plot_team_comparison, plot_team_roster
 
 def simulate_matchup(team1, team2, year):
     stats1 = get_team_stats(team1, year)
     stats2 = get_team_stats(team2, year)
+    roster1 = get_team_roster(team1, year)
+    roster2 = get_team_roster(team2, year)
 
     score1, score2 = predict_score(stats1, stats2)
     prob1, prob2 = calculate_win_probability(score1, score2)
@@ -16,9 +18,13 @@ def simulate_matchup(team1, team2, year):
         winner = team2
 
     plot_team_comparison(team1, team2, stats1, stats2)
+    plot_team_roster(team1, roster1)
+    plot_team_roster(team2, roster2)
 
-    return (f"\n{team1} ({prob1}%) vs. {team2} ({prob2}%)\n"
-            f"Predicted Score: {team1} {score1} - {score2} {team2} → Winner: {winner}")
+    return (
+        f"\n{team1} ({prob1}%) vs. {team2} ({prob2}%)\n"
+        f"Predicted Score: {team1} {score1} - {score2} {team2} → Winner: {winner}"
+    )
 
 
 

--- a/visuals.py
+++ b/visuals.py
@@ -63,3 +63,21 @@ def plot_player_comparison(player_stats, stat_type="passingYards", top_n=5):
 
 
 
+
+def plot_team_roster(team, roster):
+    """Display a team's roster as an interactive table."""
+    if not roster:
+        print("No roster data available.")
+        return
+
+    names = [f"{p.get('first_name', '')} {p.get('last_name', '')}" for p in roster]
+    positions = [p.get("position", "") for p in roster]
+    jerseys = [p.get("jersey", "") for p in roster]
+
+    table = go.Table(
+        header=dict(values=["Player", "Position", "Jersey"], fill_color="paleturquoise", align="left"),
+        cells=dict(values=[names, positions, jerseys], fill_color="lavender", align="left"),
+    )
+    fig = go.Figure(data=[table])
+    fig.update_layout(title=f"{team} Roster")
+    fig.show()


### PR DESCRIPTION
## Summary
- add `get_team_roster` to fetch roster data from CollegeFootballData API
- render roster tables via new `plot_team_roster`
- expand `simulate_matchup` to show team rosters
- test roster plotting and matchup simulation with mocked data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ed78a234833082a98f742914c09b