### PR TITLE
Visualize matchup predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This tool compares two FBS teams' season stats using data from the [CollegeFootb
 * Retrieves live team stats from the CollegeFootballData API
 * Predicts scores based on total offensive and defensive yards
 * Visualizes side-by-side stat comparisons using Plotly
+* Displays predicted scores with win probabilities in a Plotly bar chart
 * Command-line interface for interactive use
 * Includes automated tests using Pytest
 
@@ -17,7 +18,7 @@ This tool compares two FBS teams' season stats using data from the [CollegeFootb
 1. You input two FBS teams and a season year.
 2. The app fetches season-long team stats from the API.
 3. It calculates predicted scores using total yards gained and allowed.
-4. A bar graph of offensive and defensive PPG is displayed using Plotly.
+4. Bar charts visualize stat comparisons and predicted scores with win probabilities using Plotly.
 
 ---
 

--- a/matchup.py
+++ b/matchup.py
@@ -1,6 +1,6 @@
 from data_fetcher import get_team_stats, get_team_roster
 from utils import predict_score, calculate_win_probability
-from visuals import plot_team_comparison, plot_team_roster
+from visuals import plot_team_comparison, plot_team_roster, plot_game_prediction
 
 def simulate_matchup(team1, team2, year):
     stats1 = get_team_stats(team1, year)
@@ -17,6 +17,7 @@ def simulate_matchup(team1, team2, year):
     elif score2 > score1:
         winner = team2
 
+    plot_game_prediction(team1, team2, score1, score2, prob1, prob2)
     plot_team_comparison(team1, team2, stats1, stats2)
     plot_team_roster(team1, roster1)
     plot_team_roster(team2, roster2)

--- a/tests/test_matchup.py
+++ b/tests/test_matchup.py
@@ -40,6 +40,7 @@ def test_simulate_matchup_with_rosters(monkeypatch):
     monkeypatch.setattr("matchup.get_team_roster", mock_get_team_roster)
     monkeypatch.setattr("matchup.plot_team_comparison", lambda *args, **kwargs: None)
     monkeypatch.setattr("matchup.plot_team_roster", mock_plot_team_roster)
+    monkeypatch.setattr("matchup.plot_game_prediction", lambda *args, **kwargs: None)
 
     result = simulate_matchup("Team A", "Team B", 2023)
     assert "Winner" in result

--- a/visuals.py
+++ b/visuals.py
@@ -36,6 +36,26 @@ def plot_team_comparison(team1, team2, stats1, stats2):
 
     fig.show()
 
+
+def plot_game_prediction(team1, team2, score1, score2, prob1, prob2):
+    """Visualize predicted scores and win probabilities for a matchup."""
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            x=[team1, team2],
+            y=[score1, score2],
+            text=[f"{prob1}% win", f"{prob2}% win"],
+            textposition="auto",
+            name="Predicted Score",
+        )
+    )
+    fig.update_layout(
+        title=f"{team1} vs {team2} - Score Prediction",
+        xaxis_title="Team",
+        yaxis_title="Predicted Score",
+    )
+    fig.show()
+
 def plot_player_comparison(player_stats, stat_type="passingYards", top_n=5):
     filtered_players = [p for p in player_stats if p.get("statType") == stat_type]
     print(f"Found {len(filtered_players)} players with stat type: {stat_type}")


### PR DESCRIPTION
## Summary
- add `plot_game_prediction` to display predicted scores with win percentages
- call prediction plot from `simulate_matchup`
- document new visualization in README and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f2cd43e88330bd406809d9ecfc09