### PR TITLE
Use lastName for roster display

### DIFF
--- a/tests/test_matchup.py
+++ b/tests/test_matchup.py
@@ -11,8 +11,8 @@ from visuals import plot_team_roster
 def test_plot_team_roster_handles_data(monkeypatch):
     monkeypatch.setattr("visuals.go.Figure.show", lambda self: None)
     roster = [
-        {"first_name": "John", "last_name": "Doe", "position": "QB", "jersey": 12},
-        {"first_name": "Jane", "last_name": "Smith", "position": "RB", "jersey": 5},
+        {"lastName": "Doe", "position": "QB", "jersey": 12},
+        {"lastName": "Smith", "position": "RB", "jersey": 5},
     ]
 
     plot_team_roster("Test Team", roster)
@@ -28,7 +28,7 @@ def test_simulate_matchup_with_rosters(monkeypatch):
 
     def mock_get_team_roster(team, year):
         return [
-            {"first_name": "Alex", "last_name": "Player", "position": "QB", "jersey": 1}
+            {"lastName": "Player", "position": "QB", "jersey": 1}
         ]
 
     plot_calls = []

--- a/visuals.py
+++ b/visuals.py
@@ -70,12 +70,12 @@ def plot_team_roster(team, roster):
         print("No roster data available.")
         return
 
-    names = [f"{p.get('first_name', '')} {p.get('last_name', '')}" for p in roster]
+    names = [p.get("lastName", "Unknown") for p in roster]
     positions = [p.get("position", "") for p in roster]
     jerseys = [p.get("jersey", "") for p in roster]
 
     table = go.Table(
-        header=dict(values=["Player", "Position", "Jersey"], fill_color="paleturquoise", align="left"),
+        header=dict(values=["Last Name", "Position", "Jersey"], fill_color="paleturquoise", align="left"),
         cells=dict(values=[names, positions, jerseys], fill_color="lavender", align="left"),
     )
     fig = go.Figure(data=[table])


### PR DESCRIPTION
## Summary
- Display only player last names in team roster table
- Adjust roster table header to "Last Name"
- Update tests to use `lastName` in sample rosters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f2c70de48330bee8020ed10a0769