### PR TITLE
Add predicted yardage outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This tool compares two FBS teams' season stats using data from the [CollegeFootb
 
 * Retrieves live team stats from the CollegeFootballData API
 * Predicts scores based on total offensive and defensive yards
+* Forecasts each team's offensive yards and defensive yards allowed
 * Visualizes side-by-side stat comparisons using Plotly
 * Displays predicted scores with win probabilities in a Plotly bar chart
 * Command-line interface for interactive use

--- a/matchup.py
+++ b/matchup.py
@@ -1,6 +1,11 @@
 from data_fetcher import get_team_stats, get_team_roster
 from utils import predict_score, calculate_win_probability, predict_yardage
-from visuals import plot_team_comparison, plot_team_roster, plot_game_prediction
+from visuals import (
+    plot_team_comparison,
+    plot_team_roster,
+    plot_game_prediction,
+    plot_predicted_yardage,
+)
 
 def simulate_matchup(team1, team2, year):
     stats1 = get_team_stats(team1, year)
@@ -9,7 +14,8 @@ def simulate_matchup(team1, team2, year):
     roster2 = get_team_roster(team2, year)
 
     score1, score2 = predict_score(stats1, stats2)
-    yards1, yards2 = predict_yardage(stats1, stats2)
+    off_yards1, off_yards2 = predict_yardage(stats1, stats2)
+    def_yards1, def_yards2 = off_yards2, off_yards1
     prob1, prob2 = calculate_win_probability(score1, score2)
 
     winner = "Tie"
@@ -20,13 +26,15 @@ def simulate_matchup(team1, team2, year):
 
     plot_game_prediction(team1, team2, score1, score2, prob1, prob2)
     plot_team_comparison(team1, team2, stats1, stats2)
+    plot_predicted_yardage(team1, team2, off_yards1, def_yards1, off_yards2, def_yards2)
     plot_team_roster(team1, roster1)
     plot_team_roster(team2, roster2)
 
     return (
         f"\n{team1} ({prob1}%) vs. {team2} ({prob2}%)\n"
         f"Predicted Score: {team1} {score1} - {score2} {team2} → Winner: {winner}\n"
-        f"Predicted Yardage: {team1} {yards1} - {yards2} {team2}"
+        f"{team1} - Predicted Offensive Yards: {off_yards1}, Predicted Defensive Yards Allowed: {def_yards1}\n"
+        f"{team2} - Predicted Offensive Yards: {off_yards2}, Predicted Defensive Yards Allowed: {def_yards2}"
     )
 
 

--- a/tests/test_matchup.py
+++ b/tests/test_matchup.py
@@ -41,6 +41,7 @@ def test_simulate_matchup_with_rosters(monkeypatch):
     monkeypatch.setattr("matchup.plot_team_comparison", lambda *args, **kwargs: None)
     monkeypatch.setattr("matchup.plot_team_roster", mock_plot_team_roster)
     monkeypatch.setattr("matchup.plot_game_prediction", lambda *args, **kwargs: None)
+    monkeypatch.setattr("matchup.plot_predicted_yardage", lambda *args, **kwargs: None)
 
     result = simulate_matchup("Team A", "Team B", 2023)
     assert "Winner" in result

--- a/visuals.py
+++ b/visuals.py
@@ -56,6 +56,25 @@ def plot_game_prediction(team1, team2, score1, score2, prob1, prob2):
     )
     fig.show()
 
+
+def plot_predicted_yardage(team1, team2, off1, def1, off2, def2):
+    """Visualize predicted offensive yards and defensive yards allowed."""
+    categories = [team1, team2]
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(x=categories, y=[off1, off2], name="Predicted Offensive Yards")
+    )
+    fig.add_trace(
+        go.Bar(x=categories, y=[def1, def2], name="Predicted Defensive Yards Allowed")
+    )
+    fig.update_layout(
+        title=f"{team1} vs {team2} - Predicted Yardage",
+        xaxis_title="Team",
+        yaxis_title="Yards",
+        barmode="group",
+    )
+    fig.show()
+
 def plot_player_comparison(player_stats, stat_type="passingYards", top_n=5):
     filtered_players = [p for p in player_stats if p.get("statType") == stat_type]
     print(f"Found {len(filtered_players)} players with stat type: {stat_type}")


### PR DESCRIPTION
## Summary
- print predicted offensive yards and defensive yards allowed for both teams
- plot predicted yardage in a new Plotly visualization
- document yardage forecasting in the README and adjust tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950b8a1a788330b423278d094fd7df